### PR TITLE
Remove acronyms in MOI wrapper

### DIFF
--- a/src/MAiNGO.jl
+++ b/src/MAiNGO.jl
@@ -5,9 +5,10 @@
 
 # MIT License Copyright (c) 2015 Joey Huchette for Baron.jl
 
-__precompile__()
-
 module MAiNGO
+
+using Libdl: Libdl
+using MAiNGO_jll
 
 @enum EnvironmentStatus begin
     MAINGO_NOT_FOUND = 1
@@ -15,13 +16,12 @@ module MAiNGO
     MAINGO_JLL = 3
     STANDALONE = 4
 end
-maingo_lib = Ref("")
-maingo_exec = Ref("")
 
-environment_status = Ref(MAINGO_NOT_FOUND)
+const maingo_lib = Ref("")
 
-using Libdl: Libdl
-using MAiNGO_jll
+const maingo_exec = Ref("")
+
+const environment_status = Ref(MAINGO_NOT_FOUND)
 
 include("find.jl") # contains all requried subroutines for finding MAiNGO
 
@@ -120,6 +120,7 @@ mutable struct MAINGOModel
         options = Dict{String,Any}(String(key) => val for (key, val) in kwargs)
         return MAINGOModel(options)
     end
+
     function MAINGOModel(options::Dict{String,Any})
         model = new()
         model.options = options
@@ -142,9 +143,11 @@ mutable struct MAINGOModel
 end
 
 function __init__()
-    return findMAiNGO(; verbose = true)
+    findMAiNGO(; verbose = true)
+    return
 end
 
 include("util.jl")
 include("MOI_wrapper.jl")
-end
+
+end  # MAiNGO

--- a/src/moi/objective.jl
+++ b/src/moi/objective.jl
@@ -27,12 +27,19 @@ function MOI.get(model::Optimizer, ::MOI.ObjectiveSense)
 end
 
 #Declare support for linear and quadratic objective functions. Nonlinear objective function is enabled in constraints.jl
-MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{SAF}) = true
-MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{SQF}) = true
-MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{SNF}) = true
+MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}) = true
+
+function MOI.supports(::Optimizer,
+                      ::MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}})
+    return true
+end
+
+MOI.supports(::Optimizer, ::MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction}) = true
 
 function MOI.set(model::Optimizer, ::MOI.ObjectiveFunction{F},
-                 obj::F) where {F<:Union{SAF,SQF,SNF}}
+                 obj::F) where {F<:Union{MOI.ScalarAffineFunction{Float64},
+                                         MOI.ScalarQuadraticFunction{Float64},
+                                         MOI.ScalarNonlinearFunction}}
     model.inner.objective_info.expression = to_expr(obj)
     return
 end

--- a/src/moi/results.jl
+++ b/src/moi/results.jl
@@ -73,7 +73,7 @@ end
 MOI.get(model::Optimizer, ::MOI.ObjectiveValue) = model.inner.solution_info.objective_value
 
 #Get variable values at solution
-function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::VI)
+function MOI.get(model::Optimizer, ::MOI.VariablePrimal, vi::MOI.VariableIndex)
     solution_info = model.inner.solution_info
     if solution_info === nothing || solution_info.feasible_point === nothing
         error("VariablePrimal not available.")
@@ -102,7 +102,7 @@ function MOI.get(model::Optimizer, ::MOI.RawStatusString)
 end
 
 #function MOI.get(model::Optimizer, ::MOI.NodeCount)
-#	
+#
 #end
 
 #Get solution time

--- a/src/moi/util.jl
+++ b/src/moi/util.jl
@@ -1,7 +1,7 @@
 
-#Convert a affine term to symbolic expression 
-function to_expr(f::SAF)
-    f = MOIU.canonical(f)
+#Convert a affine term to symbolic expression
+function to_expr(f::MOI.ScalarAffineFunction{Float64})
+    f = MOI.Utilities.canonical(f)
     if isempty(f.terms)
         return f.constant
     else
@@ -18,8 +18,8 @@ function to_expr(f::SAF)
 end
 
 #Convert a quadratic terms to symbolic expression
-function to_expr(f::SQF)
-    f = MOIU.canonical(f)
+function to_expr(f::MOI.ScalarQuadraticFunction{Float64})
+    f = MOI.Utilities.canonical(f)
     linear_term_exprs = map(f.affine_terms) do term
         i = term.variable.value
         return :($(term.coefficient) * x[$i])
@@ -40,7 +40,7 @@ function to_expr(f::SQF)
     return expr
 end
 
-function to_expr(f::SNF)
+function to_expr(f::MOI.ScalarNonlinearFunction)
     expr = Expr(:call, f.head)
     for arg in f.args
         push!(expr.args, to_expr(arg))
@@ -53,17 +53,17 @@ to_expr(x::Real) = x
 to_expr(vi::MOI.VariableIndex) = :(x[$(vi.value)])
 
 # check_variable_indices
-function check_variable_indices(model::Optimizer, index::VI)
+function check_variable_indices(model::Optimizer, index::MOI.VariableIndex)
     @assert 1 <= index.value <= length(model.inner.variable_info)
 end
 
-function check_variable_indices(model::Optimizer, f::SAF)
+function check_variable_indices(model::Optimizer, f::MOI.ScalarAffineFunction{Float64})
     for term in f.terms
         check_variable_indices(model, term.variable)
     end
 end
 
-function check_variable_indices(model::Optimizer, f::SQF)
+function check_variable_indices(model::Optimizer, f::MOI.ScalarQuadraticFunction{Float64})
     for term in f.affine_terms
         check_variable_indices(model, term.variable)
     end
@@ -74,7 +74,7 @@ function check_variable_indices(model::Optimizer, f::SQF)
 end
 
 #How to safely access variable info data.
-function find_variable_info(model::Optimizer, vi::VI)
+function find_variable_info(model::Optimizer, vi::MOI.VariableIndex)
     check_variable_indices(model, vi)
     return model.inner.variable_info[vi.value]
 end

--- a/src/moi/variables.jl
+++ b/src/moi/variables.jl
@@ -3,7 +3,7 @@
 #Get number of variables
 MOI.get(model::Optimizer, ::MOI.NumberOfVariables) = length(model.inner.variable_info)
 function MOI.get(model::Optimizer, ::MOI.ListOfVariableIndices)
-    return VI.(1:length(model.inner.variable_info))
+    return MOI.VariableIndex.(1:length(model.inner.variable_info))
 end
 
 function MOI.add_variables(model::Optimizer, nvars::Integer)
@@ -48,9 +48,9 @@ function MOI.add_constrained_variable(model::Optimizer,
     var = VariableInfo(set.lower, set.upper, :Cont, nothing, nothing)
     push!(model.inner.variable_info, var)
     #TODO: The interface expects us to return an index for the constraints (but we dont keep track of constraint indices).
-    #CI(...) needs be changed if this were to be implemented.
+    #MOI.ConstraintIndex(...) needs be changed if this were to be implemented.
 
-    return VI(length(model.inner.variable_info)),
+    return MOI.VariableIndex(length(model.inner.variable_info)),
            MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{Float64}}(length(model.inner.variable_info))
 end
 
@@ -59,7 +59,7 @@ function MOI.add_constrained_variable(model::Optimizer,
                                       set::MOI.Integer)
     var = VariableInfo(-1e6, 1e6, :Int, nothing, nothing)
     push!(model.inner.variable_info, var)
-    return VI(length(model.inner.variable_info)),
+    return MOI.VariableIndex(length(model.inner.variable_info)),
            MOI.ConstraintIndex{MOI.VariableIndex,MOI.Integer}(length(model.inner.variable_info))
 end
 
@@ -68,7 +68,7 @@ function MOI.add_constrained_variable(model::Optimizer,
                                       set::MOI.ZeroOne)
     var = VariableInfo(0, 1, :Bin, nothing, nothing)
     push!(model.inner.variable_info, var)
-    return VI(length(model.inner.variable_info)),
+    return MOI.VariableIndex(length(model.inner.variable_info)),
            MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(length(model.inner.variable_info))
 end
 
@@ -127,21 +127,21 @@ function MOI.add_constraint(model::Optimizer, v::MOI.VariableIndex,
 end
 
 #Declare support for setting names
-#MOI.supports(model::Optimizer, ::MOI.VariableName, ::Type{VI}) = true
+#MOI.supports(model::Optimizer, ::MOI.VariableName, ::Type{MOI.VariableIndex}) = true
 
 #Implement  setting variable names
-function MOI.set(model::Optimizer, ::MOI.VariableName, vi::VI, name::String)
+function MOI.set(model::Optimizer, ::MOI.VariableName, vi::MOI.VariableIndex, name::String)
     check_variable_indices(model, vi)
     return model.inner.variable_info[vi.value].name = name
 end
 
 #Implement  getting variable names
-function MOI.get(model::Optimizer, ::MOI.VariableName, vi::VI)::String
+function MOI.get(model::Optimizer, ::MOI.VariableName, vi::MOI.VariableIndex)::String
     check_variable_indices(model, vi)
     return model.inner.variable_info[vi.value].name
 end
 
-function MOI.set(model::Optimizer, attr::MOI.VariableName, vi::VI, value)
+function MOI.set(model::Optimizer, attr::MOI.VariableName, vi::MOI.VariableIndex, value)
     check_variable_indices(model, vi)
     return model.inner.variable_info[vi.value].name = value
 end
@@ -159,7 +159,7 @@ function MOI.set(model::Optimizer, ::MOI.VariablePrimalStart,
     return
 end
 
-function MOI.get(model::Optimizer, ::MOI.VariablePrimalStart, vi::VI)
+function MOI.get(model::Optimizer, ::MOI.VariablePrimalStart, vi::MOI.VariableIndex)
     check_variable_indices(model, vi)
     return model.inner.variable_info[vi.value].start
 end


### PR DESCRIPTION
You don't have to merge this one, but I would encourage you to remove the use of acronyms. I did the same in BARON last year: https://github.com/jump-dev/BARON.jl/pull/62. It makes the code much more readable for people unfamiliar with MOI.